### PR TITLE
prefetch second cacheline of mbufs on alloc

### DIFF
--- a/lib/librte_mbuf/rte_mbuf.h
+++ b/lib/librte_mbuf/rte_mbuf.h
@@ -528,6 +528,7 @@ static inline struct rte_mbuf *__rte_mbuf_raw_alloc(struct rte_mempool *mp)
 	if (rte_mempool_get(mp, &mb) < 0)
 		return NULL;
 	m = (struct rte_mbuf *)mb;
+	rte_prefetch0(&m->cacheline1);
 	RTE_MBUF_ASSERT(rte_mbuf_refcnt_read(m) == 0);
 	rte_mbuf_refcnt_set(m, 1);
 	return (m);


### PR DESCRIPTION
this improves the throughput of a simple tx-only application by 11% in
the full-featured ixgbe tx path and by 14% in the simple tx path.