### PR TITLE
travis: add intial travis ci config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+
+sudo: required
+
+compiler:
+  - gcc
+  - clang
+
+install:
+  - sudo apt-get update
+  - sudo apt-get install linux-headers-generic
+  - sudo ln -s /lib/modules/*-generic /lib/modules/$(uname -r)
+
+script:
+  - make T=x86_64-native-linuxapp-$CC install


### PR DESCRIPTION
Add initial yaml config file for Travis CI:

    https://travis-ci.org/

This version tests DPDK compilation with gcc and clang.

Closes issue #4.

Signed-off-by: John McNamara <john.mcnamara@intel.com>